### PR TITLE
Chapter 1 default path working "out of the box"

### DIFF
--- a/ch01-twitter/Chapter1.ipynb
+++ b/ch01-twitter/Chapter1.ipynb
@@ -468,7 +468,9 @@
      "collapsed": false,
      "input": [
       "import json\n",
-      "statuses = json.loads(open('data/MentionSomeoneImportantForYou.json').read())\n",
+      # If you're using a local copy of your own IPython, use the line below
+      # "statuses = json.loads(open('data/MentionSomeoneImportantForYou.json').read())\n",
+      "statuses = json.loads(open('resources/ch01-twitter/data/MentionSomeoneImportantForYou.json').read())\n",
       "\n",
       "# The result of the list comprehension is a list with only one element that\n",
       "# can be accessed by its index and set to the variable t\n",


### PR DESCRIPTION
I changed line 471 so that it "defaults" to the user running this chapter "out of the box" through IPython where their path will be /home/vagrant/mtsw2e/ipynb

A user running these commands on their own env would know to comment that out :). Perhaps it might be nice to make this path dependent on a variable at the beginning of the notebook.

``` python
>>> import commands
>>> commands.getoutput("pwd")
'/home/vagrant/mtsw2e/ipynb'
```
