### PR TITLE
Update Chapter 9 - Twitter Cookbook.ipynb

### DIFF
--- a/ipynb/Chapter 9 - Twitter Cookbook.ipynb
+++ b/ipynb/Chapter 9 - Twitter Cookbook.ipynb
@@ -984,7 +984,7 @@
       "            else: # user_id\n",
       "                response = twitter_api_func(user_id=user_id, cursor=cursor)\n",
       "\n",
-      "            ids += response['ids']\n",
+      "            ids += response['ids'] #This won't work with protected accounts \n",
       "            cursor = response['next_cursor']\n",
       "        \n",
       "            print >> sys.stderr, 'Fetched {0} total {1} ids for {2}'.format(len(ids), label, (user_id or screen_name))\n",


### PR DESCRIPTION
Example 19 throws an error if it encounters a protected account:
    ids += response['ids']
TypeError: 'NoneType' object is not subscriptable
