### PR TITLE
add import nltk

### DIFF
--- a/ipynb/Chapter 3 - Mining LinkedIn.ipynb
+++ b/ipynb/Chapter 3 - Mining LinkedIn.ipynb
@@ -522,6 +522,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
+      "import nltk\n",
       "ceo_bigrams = nltk.bigrams(\"Chief Executive Officer\".split(), pad_right=True, \n",
       "                                                              pad_left=True)\n",
       "cto_bigrams = nltk.bigrams(\"Chief Technology Officer\".split(), pad_right=True, \n",


### PR DESCRIPTION
Hey there - noticed the "import nltk" was missing from chapter 3 ipython notebook. Just a minor fix for that.

Cheers - and thanks again for the presentation!
