### PR TITLE
Getting rid of multiple retweets

### DIFF
--- a/ipynb/Chapter 1 - Mining Twitter.ipynb
+++ b/ipynb/Chapter 1 - Mining Twitter.ipynb
@@ -399,7 +399,7 @@
       "# Slice off the first 5 from the sorted results and display each item in the tuple\n",
       "\n",
       "pt = PrettyTable(field_names=['Count', 'Screen Name', 'Text'])\n",
-      "[ pt.add_row(row) for row in sorted(retweets, reverse=True)[:5] ]\n",
+      "[ pt.add_row(row) for row in sorted(set(retweets), reverse=True)[:5] ]\n",
       "pt.max_width['Text'] = 50\n",
       "pt.align= 'l'\n",
       "print pt"


### PR DESCRIPTION
For some hashtags, you get 5 identical retweets as there are no other retweets in the search. A set(retweets) could make sense here, because technically, a retweet does not create a new tweet, but just adds a new retweet entity to the original tweet.
