### PR TITLE
Change Chapter 5 - Example 3 pseudocode cell type to Raw Text

### DIFF
--- a/ipynb/Chapter 5 - Mining Web Pages.ipynb
+++ b/ipynb/Chapter 5 - Mining Web Pages.ipynb
@@ -91,9 +91,9 @@
      ]
     },
     {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
+     "cell_type": "raw",
+     "metadata": {},
+     "source": [
       "Create an empty graph\n",
       "Create an empty queue to keep track of nodes that need to be processed\n",
       "\n",


### PR DESCRIPTION
Cell for Example 3. Pseudocode for a breadth-first search

Pseudocode should not be in a code Ipython notebook cell.
Rather it should be in a Raw Text cell so it retains formatting but
the notebook does not attempt to run it.
