### PR TITLE
fix import centroid error

### DIFF
--- a/ipynb/Chapter 3 - Mining LinkedIn.ipynb
+++ b/ipynb/Chapter 3 - Mining LinkedIn.ipynb
@@ -1,6 +1,7 @@
 {
  "metadata": {
-  "name": ""
+  "name": "",
+  "signature": "sha256:6f0eb52b35cd124923ae4aa1a42ddbaf10ce3476a99e3178a08e7807b1d2ff83"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -1022,7 +1023,8 @@
       "import json\n",
       "from urllib2 import HTTPError\n",
       "from geopy import geocoders\n",
-      "from cluster import KMeansClustering, centroid\n",
+      "from cluster import KMeansClustering\n",
+      "from cluster.util import centroid\n",
       "\n",
       "# A helper function to munge data and build up an XML tree.\n",
       "# It references some code tucked away in another directory, so we have to\n",


### PR DESCRIPTION
http://python-cluster.readthedocs.org/en/latest/apidoc/cluster.util.html

when importing centroid, must use: from cluster.util import centroid
versus: from cluster import centroid
